### PR TITLE
Make Top Sites the default tab.

### DIFF
--- a/packages/extension/src/app.js
+++ b/packages/extension/src/app.js
@@ -101,8 +101,8 @@ const App = memo(() => {
       ) : null}
       <Settings>
         {/* Inside settings to keep ordering */}
-        <Plugins />
         <TopSites />
+        <Plugins />
       </Settings>
       <InfoModal
         zIndex="1000"


### PR DESCRIPTION
## Description

So the version of Mujo on the store got taken down. I have been scratching my head because not much has changed with the plugin. 

> **Items on the Chrome Web Store should work and provide the promised functionality that aligns with the description of the item**. Please review your item and make the necessary changes so that it provides the function/service included in the item’s description.

Here is the highlight from the email I received, I updated the description to put less emphasis on the features that are enabled by optional permissions.

```txt
It is good to take little micro breaks throughout the day. Just paying attention to your breath and being present with your current situation can make you think more in depth about the task in front of you. Mujō is a new tab page that will try to get you to take those little micro break.

Mujō comes with:

- A breathing exercise
- Notification when you have been on your computer for a long time
- Subtle nudges to take a break
- Ability to customize the breathing exercise

🔑after enabling some optional permissions for Screen Time you then will get access to:

- Screen timer
- Rage click detection
- Site specific break Timer ( you need to enable per site )

⚡️What's New! 2.0.5

- UI is more responsive to activity resets
- bug fixes! 


💌Any feedback is appreciated!
```

Seems like this did not fix the issue, and the only other think of was the new screen that is verbose about enabling screen time.

<img width="710" alt="Screen Shot 2019-10-10 at 4 49 09 PM" src="https://user-images.githubusercontent.com/578259/66614455-f972cb00-eb7d-11e9-97b7-1e8fb1d4c455.png">

> NOTE: this has been this way since screen time has introduced and this was just a UI update that is more verbose on why 

All I can guess is now Google thinks all the functionality is enabled by clicking that button.

## Changes

* make top sites the default tab

<img width="534" alt="Screen Shot 2019-10-10 at 5 08 51 PM" src="https://user-images.githubusercontent.com/578259/66615226-ac442880-eb80-11e9-904d-77d72db15863.png">

If this does not work not sure what to do but beside try to keep reaching out to Google...