### PR TITLE
Filter out random errors in Sentry

### DIFF
--- a/packages/extension/src/lib/error-tracker.js
+++ b/packages/extension/src/lib/error-tracker.js
@@ -8,7 +8,16 @@ const { getStorage } = Extension
 export const createTracker = ({ dsn, environment }) => {
   const hasDSN = !!dsn
   if (hasDSN) {
-    Sentry.init({ dsn, environment })
+    Sentry.init({
+      dsn,
+      environment,
+      ignoreErrors: [
+        // Random extension errors some because users are not
+        // logged into their browser
+        'Non-Error promise rejection captured with keys',
+        'Extension context invalidated.',
+      ],
+    })
     getStorage(ID_KEY).then(id => {
       Sentry.setUser({ id })
     })


### PR DESCRIPTION
## Description

Just reenabled sentry, and now I see why I go over my quota.

<img width="1142" alt="Screen Shot 2019-10-12 at 9 07 52 AM" src="https://user-images.githubusercontent.com/578259/66704340-e1ab5c00-eccf-11e9-88b7-e46ae49b2981.png">

This error happens every time a user visits the NTP and is not signed in. Also here I am also filtering out some random extension errors that can happen.