### PR TITLE
Update paths on E2E

### DIFF
--- a/packages/extension/src/e2e.test.js
+++ b/packages/extension/src/e2e.test.js
@@ -1,11 +1,8 @@
 import path from 'path'
 import { AsyncHelpers } from '@mujo/utils'
 import puppeteer from 'puppeteer'
-import {
-  SET_STORAGE,
-  SITE_TIME_KEY,
-  APP_READY_KEY,
-} from './constants'
+import manifest from '../build/manifest.json'
+import { APP_READY_KEY } from './constants'
 
 const { wait } = AsyncHelpers
 const TEST_TIMEOUT = 20000 // extend test timeout sinces its E2E
@@ -13,6 +10,25 @@ const TEST_TIMEOUT = 20000 // extend test timeout sinces its E2E
 let browser
 let page
 const BUILD_PATH = path.resolve(__dirname, '../build')
+
+let extensionId = null
+
+const getExtensionId = async () => {
+  const dummyPage = await browser.newPage()
+  await dummyPage.waitFor(2000) // arbitrary wait time.
+
+  const targets = await browser.targets()
+  const extensionTarget = targets.find(
+    ({ _targetInfo }) =>
+      _targetInfo.title === manifest.name &&
+      _targetInfo.type === 'background_page'
+  )
+  // eslint-disable-next-line no-underscore-dangle
+  const extensionUrl = extensionTarget._targetInfo.url || ''
+  const [, , extensionID] = extensionUrl.split('/')
+  dummyPage.close()
+  return extensionID
+}
 
 beforeAll(async () => {
   browser = await puppeteer.launch({
@@ -29,6 +45,8 @@ beforeAll(async () => {
     },
     slowMo: 100,
   })
+
+  extensionId = await getExtensionId()
 })
 
 afterAll(async () => {
@@ -63,7 +81,7 @@ const waitDOMLoaded = async () =>
 test(
   'newtab page should have a player',
   async () => {
-    await page.goto('chrome://newtab')
+    await page.goto(`chrome-extension://${extensionId}/index.html`)
     await waitDOMLoaded()
     const el = await page.$('[data-testid="breath-player"]')
     await wait(500)
@@ -74,9 +92,11 @@ test(
 
 // TODO need a good indicator that deeplinking is working
 test(
-  'newtab page should be able to deeplink into a exercisee',
+  'newtab page should be able to deeplink into a exercise',
   async () => {
-    await page.goto('chrome://newtab?play=true')
+    await page.goto(
+      `chrome-extension://${extensionId}/index.html?play=true`
+    )
     await waitDOMLoaded()
     await wait(1000)
     const el = await page.$('[data-testid="breath-player--count"]')
@@ -86,44 +106,6 @@ test(
       'textContent'
     )).jsonValue()
     expect(initialCount.trim()).toBe('5')
-  },
-  TEST_TIMEOUT
-)
-
-const screenTimeMock = {
-  'https://foo.com': 1000000,
-  'https://www.bar.com': 200000,
-  'https://qux.org': 65000,
-}
-
-// TODO: replace this test
-test.skip(
-  'newtab should display screen time chart',
-  async () => {
-    await page.goto('chrome://newtab')
-    await waitDOMLoaded()
-    await page.evaluate(
-      async (event, key, value) => {
-        await new Promise(resolve => {
-          chrome.runtime.sendMessage(
-            chrome.runtime.id,
-            {
-              event,
-              key,
-              value,
-            },
-            resolve
-          )
-        })
-        return [window.chrome.runtime.id, event, key, value]
-      },
-      SET_STORAGE,
-      SITE_TIME_KEY,
-      screenTimeMock
-    )
-    await wait(500)
-    const el = await page.$('[data-testid="graph"]')
-    expect(el).not.toBe(null)
   },
   TEST_TIMEOUT
 )


### PR DESCRIPTION
## Description 

This updates the pathing to the e2e to use the extension id path instead of `chrome://new-tab` this should avoid issues with conditional new tab page breaking e2e, and allow us to navigate to more pages on the application.

* also removes old skipped e2e test