### PR TITLE
Firefox support

### DIFF
--- a/packages/extension/src/background/conditional-new-tab.js
+++ b/packages/extension/src/background/conditional-new-tab.js
@@ -1,19 +1,19 @@
 import { Extension } from '@mujo/utils'
-import { NEW_TAB, CONDITIONAL_NEW_TAB_PAGE_KEY } from '../constants'
+import {
+  NEW_TAB,
+  NEW_TAB_FIREFOX,
+  CONDITIONAL_NEW_TAB_PAGE_KEY,
+} from '../constants'
 import { storage } from './storage'
 
 const { tabs, runtime } = Extension
 
 export const onConditionalNewTab = async tab => {
   const isEnabled = await storage.get(CONDITIONAL_NEW_TAB_PAGE_KEY)
-  if (tab.url === NEW_TAB) {
-    // I am checking for undefined for the first time only
+
+  if (tab.url === NEW_TAB || tab.url === NEW_TAB_FIREFOX) {
     if (isEnabled || isEnabled === undefined) {
-      tabs.update(
-        tab.id,
-        { url: runtime.getURL('../index.html') },
-        () => {}
-      )
+      tabs.update(tab.id, { url: runtime.getURL('../index.html') })
     }
   }
 }

--- a/packages/extension/src/constants.js
+++ b/packages/extension/src/constants.js
@@ -94,3 +94,4 @@ export const SCREEN_TIME_PERMISSIONS = {
 
 // optional new tab page
 export const NEW_TAB = 'chrome://newtab/'
+export const NEW_TAB_FIREFOX = 'about:newtab'

--- a/packages/extension/src/hooks/use-extension/use-topsites-api.js
+++ b/packages/extension/src/hooks/use-extension/use-topsites-api.js
@@ -4,6 +4,10 @@ import { DEFAULT_URLS } from '../../constants'
 
 const { topSites } = Extension
 
+const getTopSites = async set => {
+  set(await topSites.get())
+}
+
 export const useTopsitesAPI = ({ setTopSites }) => {
   const [hasRefreshTopSites, setHasRefreshedTopSites] = useState(
     false
@@ -11,7 +15,7 @@ export const useTopsitesAPI = ({ setTopSites }) => {
   useEffect(() => {
     if (!hasRefreshTopSites && topSites) {
       try {
-        topSites.get(setTopSites)
+        getTopSites(setTopSites)
       } catch (e) {
         setTopSites(DEFAULT_URLS)
       }

--- a/packages/utils/package-lock.json
+++ b/packages/utils/package-lock.json
@@ -7260,6 +7260,11 @@
         "makeerror": "1.0.x"
       }
     },
+    "webextension-polyfill": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.6.0.tgz",
+      "integrity": "sha512-PlYwiX8e4bNZrEeBFxbFFsLtm0SMPxJliLTGdNCA0Bq2XkWrAn2ejUd+89vZm+8BnfFB1BclJyCz3iKsm2atNg=="
+    },
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -104,7 +104,8 @@
     "@mujo/jest-webextension-mock": "^3.5.0",
     "babel-jest": "^24.9.0",
     "punycode": "^2.1.1",
-    "react-spring": "^8.0.27"
+    "react-spring": "^8.0.27",
+    "webextension-polyfill": "^0.6.0"
   },
   "gitHead": "1a24f20513b5e7fa7d2e3d0245142cc61a4ae337"
 }


### PR DESCRIPTION
## Description

This makes the base of Mujo compatible with Firefox, additional changes may need to occur to be able to get the extension to have full support for Firefox since a majority of the APIs are exposed directly in the Extension util.

## Current issues


- [ ] Chrome favicons are not supported in Firefox.
- [ ] There are quite a few warnings from a few manifest differences. 
  * Error processing content_security_policy: SyntaxError: ‘script-src’ directive contains a forbidden http: protocol source
  * Error processing permissions.4: Value "background" must either: must either [must either [be one of ["clipboardRead", "clipboardWrite", "geolocation", "idle", "notifications"], be one of ["bookmarks"], be one of ["find"], be one of ["history"], be one of ["menus.overrideContext"], be one of ["search"], be one of ["browserSettings"], be one of ["cookies"], be one of ["downloads", "downloads.open"], be one of ["topSites"], be one of ["webNavigation"], be one of ["activeTab", "tabs", "tabHide"], or be one of ["webRequest", "webRequestBlocking"]], be one of ["alarms", "mozillaAddons", "storage", "unlimitedStorage"], be one of ["browsingData"], be one of ["devtools"], be one of ["captivePortal"], be one of ["identity"], be one of ["geckoProfiler"], be one of ["menus", "contextMenus"], be one of ["normandyAddonStudy"], be one of ["pkcs11"], be one of ["sessions"], be one of ["contextualIdentities"], be one of ["dns"], be one of ["management"], be one of ["networkStatus"], be one of ["privacy"], be one of ["proxy"], be one of ["nativeMessaging"], be one of ["urlbar"], match the pattern /^experiments(\.\w+)+$/, be one of ["telemetry"], or be one of ["theme"]], or must either [be one of ["<all_urls>"], must either [match the pattern /^(https?|wss?|file|ftp|\*):\/\/(\*|\*\.[^*/]+|[^*/]+)\/.*$/, or match the pattern /^file:\/\/\/.*$/], or match the pattern /^resource:\/\/(\*|\*\.[^*/]+|[^*/]+)\/.*$|^about:/]
  * Error processing permissions.6: Value "chrome://favicon/" must either: must either [must either [be one of ["clipboardRead", "clipboardWrite", "geolocation", "idle", "notifications"], be one of ["bookmarks"], be one of ["find"], be one of ["history"], be one of ["menus.overrideContext"], be one of ["search"], be one of ["browserSettings"], be one of ["cookies"], be one of ["downloads", "downloads.open"], be one of ["topSites"], be one of ["webNavigation"], be one of ["activeTab", "tabs", "tabHide"], or be one of ["webRequest", "webRequestBlocking"]], be one of ["alarms", "mozillaAddons", "storage", "unlimitedStorage"], be one of ["browsingData"], be one of ["devtools"], be one of ["captivePortal"], be one of ["identity"], be one of ["geckoProfiler"], be one of ["menus", "contextMenus"], be one of ["normandyAddonStudy"], be one of ["pkcs11"], be one of ["sessions"], be one of ["contextualIdentities"], be one of ["dns"], be one of ["management"], be one of ["networkStatus"], be one of ["privacy"], be one of ["proxy"], be one of ["nativeMessaging"], be one of ["urlbar"], match the pattern /^experiments(\.\w+)+$/, be one of ["telemetry"], or be one of ["theme"]], or must either [be one of ["<all_urls>"], must either [match the pattern /^(https?|wss?|file|ftp|\*):\/\/(\*|\*\.[^*/]+|[^*/]+)\/.*$/, or match the pattern /^file:\/\/\/.*$/], or match the pattern /^resource:\/\/(\*|\*\.[^*/]+|[^*/]+)\/.*$|^about:/]
  * Error processing browser_action.defaultIcon: An unexpected property was found in the WebExtension manifest.
  * Error processing offline_enabled: An unexpected property was found in the WebExtension manifest.

